### PR TITLE
fix(inthewild): disable fetching inthewild db

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -11,5 +11,6 @@ go-exploitdb --dbpath /vuls/go-exploitdb.sqlite3 fetch exploitdb
 echo "Updating from githubrepos..."
 go-exploitdb --dbpath /vuls/go-exploitdb.sqlite3 fetch githubrepos
 
-echo "Updating from inthewild..."
-go-exploitdb --dbpath /vuls/go-exploitdb.sqlite3 fetch inthewild
+# Fetching inthewild is disabled because the following bug broke it: https://github.com/vulsio/go-exploitdb/issues/149
+# echo "Updating from inthewild..."
+# go-exploitdb --dbpath /vuls/go-exploitdb.sqlite3 fetch inthewild


### PR DESCRIPTION
## Description

I disabled fetching inthewild db because the following bug broke it: https://github.com/vulsio/go-exploitdb/issues/149

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
