### PR TITLE
Update CI workflow to enable support for merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  merge_group:
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Description

This adds the merge_group trigger to the CI workflows to ensure they run as part of the merge queue.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[X] Other (please describe)  CI/CD

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
